### PR TITLE
Return input value even if the change event was not triggered

### DIFF
--- a/lib/kano-register/kano-email-field.js
+++ b/lib/kano-register/kano-email-field.js
@@ -14,7 +14,7 @@ module.exports = function () {
             value: {
                 attribute: {},
                 get: function () {
-                    return this.data.value;
+                    return this.input ? this.input.value : '';
                 },
                 set: function (val) {
                     this.valueSetter(val, true);

--- a/lib/kano-register/kano-password-field.js
+++ b/lib/kano-register/kano-password-field.js
@@ -18,7 +18,7 @@ module.exports = function () {
             value: {
                 attribute: {},
                 get: function () {
-                    return this.data.value;
+                    return this.input ? this.input.value : '';
                 },
                 set: function (val) {
                     this.valueSetter(val, true);

--- a/lib/kano-register/kano-username-field.js
+++ b/lib/kano-register/kano-username-field.js
@@ -18,7 +18,7 @@ module.exports = function (api) {
             value: {
                 attribute: {},
                 get: function () {
-                    return this.data.value;
+                    return this.input ? this.input.value : '';
                 },
                 set: function (val) {
                     this.valueSetter(val, true);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kano-world-sdk",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Kano World SDK",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Switching to the 'change' event on previous commit provoked a bug. If you submit the form directly after editing an input, the 'change' event is not triggered and the validation not made. Leaving empty the value of the element.
