### PR TITLE
Remove request-promise and rely on fetch

### DIFF
--- a/lib/util/mixed.js
+++ b/lib/util/mixed.js
@@ -1,13 +1,8 @@
-var request = require('request-promise'),
-    haikunate = require('haikunator'),
+var haikunate = require('haikunator'),
     DINOPASS_URL = 'http://www.dinopass.com/password';
 
 function getPass (type) {
-    return request({
-        method: 'GET',
-        url:  DINOPASS_URL + '/' + type,
-        withCredentials: false
-    })
+    return fetch(DINOPASS_URL + '/' + type)
     .catch(function () {
         return haikunate({delimiter: ''});
     });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "api-service": "^1.0.0",
     "browserify": "^6.3.3",
     "haikunator": "^1.0.1",
-    "request-promise": "^0.4.3",
     "watchify": "^2.1.1",
     "x-tag": "^1.5.6"
   }


### PR DESCRIPTION
request-promise uses bluebird which is insanely big. This removes the dependency and uses fetch instead. This means that this SDK now assumes that the browser it is used in implements fetch or a polyfill is used in the project
