### PR TITLE
Making email validation regex case insensitive

### DIFF
--- a/lib/kano-register/kano-email-field.js
+++ b/lib/kano-register/kano-email-field.js
@@ -70,7 +70,8 @@ module.exports = function () {
                 }
             },
             getFormatErrors: function (email) {
-                if (!/^[_a-z0-9-\+]+(\.[_a-z0-9-\+]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]+)$/.test(email)) {
+                var emailRegex = /^[_a-z0-9-\+]+(\.[_a-z0-9-\+]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]+)$/i;
+                if (!emailRegex.test(email)) {
                     return ['be valid!'];
                 }
                 return null;


### PR DESCRIPTION
Related to: https://trello.com/c/x10LFzNS/948-kano-world-entering-capital-letters-for-first-letter-in-email-gives-error-message